### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/check_on_branch.yml
+++ b/.github/workflows/check_on_branch.yml
@@ -19,8 +19,8 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::347082780157:role/inbo-n2kmonitoring-shared-infra-eu-west-1-unittest-role
           aws-region: eu-west-1
-      - uses: inbo/actions/check_pkg@main
+      - uses: inbo/actions/check_pkg@5ad8ad6a75c216b77713aa14ebaef30d76ee1463 # main

--- a/.github/workflows/check_on_branch.yml
+++ b/.github/workflows/check_on_branch.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::347082780157:role/inbo-n2kmonitoring-shared-infra-eu-west-1-unittest-role
           aws-region: eu-west-1
-      - uses: inbo/actions/check_pkg@5ad8ad6a75c216b77713aa14ebaef30d76ee1463 # main
+      - uses: inbo/actions/check_pkg@main

--- a/.github/workflows/check_on_different_r_os.yml
+++ b/.github/workflows/check_on_different_r_os.yml
@@ -37,14 +37,14 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           extra-repositories: https://inla.r-inla-download.org/R/stable
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: linux dependencies
         if: runner.os == 'linux'
@@ -59,17 +59,17 @@ jobs:
           sudo make install
           ldd --version
       
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::347082780157:role/inbo-n2kmonitoring-shared-infra-eu-west-1-unittest-role
           aws-region: eu-west-1
 
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           error-on: '"error"'

--- a/.github/workflows/check_on_main.yml
+++ b/.github/workflows/check_on_main.yml
@@ -21,8 +21,8 @@ jobs:
       contents: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::347082780157:role/inbo-n2kmonitoring-shared-infra-eu-west-1-unittest-role
           aws-region: eu-west-1
-      - uses: inbo/actions/check_pkg@main
+      - uses: inbo/actions/check_pkg@5ad8ad6a75c216b77713aa14ebaef30d76ee1463 # main

--- a/.github/workflows/check_on_main.yml
+++ b/.github/workflows/check_on_main.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::347082780157:role/inbo-n2kmonitoring-shared-infra-eu-west-1-unittest-role
           aws-region: eu-west-1
-      - uses: inbo/actions/check_pkg@5ad8ad6a75c216b77713aa14ebaef30d76ee1463 # main
+      - uses: inbo/actions/check_pkg@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Get tag
         run: |
           git fetch --tags --force
@@ -23,7 +23,7 @@ jobs:
           TAG_BODY=$(git tag --contains $(git rev-parse HEAD) --format='%(contents)')
           echo "tag=$TAG" >> $GITHUB_ENV
           echo "$TAG_BODY" > body.md
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           name: Release ${{ env.tag }}
           tag: ${{ env.tag }}


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._